### PR TITLE
Add Reock score updater

### DIFF
--- a/evaltools/geography/__init__.py
+++ b/evaltools/geography/__init__.py
@@ -6,11 +6,13 @@ Provides ease-of-use functionality for geographic and geometric operations.
 from .dissolve import dissolve
 from .dualgraph import dualgraph
 from .unitmap import unitmap, invert
+from .scores import reock
 from ..processing import Graph, Partition
 
 __all__ = [
     "dissolve",
     "dualgraph",
     "unitmap",
-    "invert"
+    "invert",
+    "reock"
 ]

--- a/evaltools/geography/scores.py
+++ b/evaltools/geography/scores.py
@@ -1,0 +1,60 @@
+"""Auxiliary and specialized geographical scores for plan evaluation."""
+import numpy as np
+import geopandas as gpd
+from typing import Dict, Callable, Union, Any
+from cv2 import minEnclosingCircle
+from networkx import Graph
+from gerrychain import Partition
+from shapely.ops import unary_union
+from math import pi
+
+
+def reock(
+    geodata: Union[gpd.GeoDataFrame, Graph]
+) -> Callable[[Partition], Dict[Any, float]]:
+    """Makes a Reock score function specialized to `geodata`.
+
+    The Reock score of a district is its area defined by the area of its
+    minimum enclosing circle. Computing the area of this circle is nontrivial,
+    and the Reock score is distinct from other popular compactness scores
+    (cut edges, Polsby-Popper) in its reliance on full district geometries
+    (rather than district areas and perimeters, which can be computed
+    efficiently from unit-level statistics).
+
+    We precompute convex hulls of all geometries in `geodata` and
+    build an index. The resulting score function uses this index for
+    fast geometric computations; the function can only be used with
+    dual graphs derived from `geodata`.
+
+    :param geodata: Geographical data to precompute geometries from.
+      May be a `geopandas.GeoDataFrame` or a `networkx.Graph` with
+      a `geometry` column.
+    :return: A per-district Reock score updater specialized to `geodata`.
+    """
+    if isinstance(geodata, gpd.GeoDataFrame):
+        geometries = dict(geodata.geometry.apply(lambda p: p.convex_hull))
+    elif isinstance(geodata, Graph):
+        geometries = {
+            node: geom.convex_hull
+            for node, geom in geodata.nodes('geometry')
+        }
+    else:
+        raise ValueError(
+            'Geodata must be a GeoDataFrame or a gerrychain.Graph.')
+
+    def score_fn(partition: Partition) -> Dict[Any, float]:
+        boundary_nodes = set.union(*(set(e) for e in partition['cut_edges']))
+        part_scores = {}
+
+        for part, nodes in partition.parts.items():
+            geom = unary_union([
+                geometries[node] for node in nodes if node in boundary_nodes
+            ]).convex_hull
+            coords = np.array(geom.exterior.coords.xy).T.astype(np.float32)
+            _, radius = minEnclosingCircle(coords)
+            score = float(partition['area'][part] / (pi * radius**2))
+            assert 0 < score < 1
+            part_scores[part] = score
+        return part_scores
+
+    return score_fn

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     "pandas", "scipy", "networkx", "geopandas", "shapely", "matplotlib",
-    "gerrychain", "sortedcontainers", "gurobipy"
+    "gerrychain", "sortedcontainers", "gurobipy", "jsonlines", "opencv-python"
 ]
 
 setup(

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -1,8 +1,11 @@
 
-from evaltools.geography import dissolve, dualgraph, unitmap, invert
+from evaltools.geography import dissolve, dualgraph, unitmap, invert, reock
+from gerrychain.grid import Grid
+from shapely.geometry import box
 import geopandas as gpd
 from pathlib import Path
 import os
+import math
 
 root = Path(os.getcwd()) / Path("tests/test-resources/")
 
@@ -73,6 +76,60 @@ def test_unitmap():
     # Assert that we have a dict and that it has as many keys as counties.
     assert type(inverse) is dict
     assert len(inverse) == len(counties)
+
+
+def test_reock_score_squares_geodataframe():
+    grid = Grid((10, 10))
+    gdf = gpd.GeoDataFrame([
+        {'node': (x, y), 'geometry': box(x, y, x + 1, y + 1)}
+        for (x, y) in grid.graph
+    ]).set_index('node')
+    score_fn = reock(gdf)
+
+    # The Reock score of a square inscribed in a circle is
+    # area(square) / area(circle) = 2/π.
+    expected_dist_score = 2/ math.pi
+    scored = score_fn(grid)
+
+    assert scored.keys() == grid.parts.keys()
+    for dist_score in scored.values():
+        assert abs(dist_score - expected_dist_score) < 1e-4
+
+
+def test_reock_score_squares_graph():
+    grid = Grid((10, 10))
+    for (x, y), data in grid.graph.nodes(data=True):
+        data['geometry'] = box(x, y, x + 1, y + 1)
+    score_fn = reock(grid.graph)
+
+    # The Reock score of a square inscribed in a circle is
+    # area(square) / area(circle) = 2/π.
+    expected_dist_score = 2 / math.pi
+    scored = score_fn(grid)
+
+    assert scored.keys() == grid.parts.keys()
+    for dist_score in scored.values():
+        assert abs(dist_score - expected_dist_score) < 1e-4
+
+
+def test_reock_score_disconnected():
+    grid = Grid((10, 10))
+    for (x, y), data in grid.graph.nodes(data=True):
+        data['geometry'] = box(x, y, x + 1, y + 1)
+    score_fn = reock(grid.graph)
+
+    # Break district 0 into two disconnected pieces 
+    # (while preserving convex hull perimeter),
+    # adding a disconnected component to district 3
+    # (quadrupling convex hull perimeter).
+    grid_disconnected = grid.flip({(0, 1): 3, (1, 0): 3})
+
+    scored = score_fn(grid_disconnected)
+    assert scored.keys() == grid_disconnected.parts.keys()
+    assert abs(scored[0] - ((23 / 25) * (2 / math.pi))) < 1e-4
+    assert abs(scored[1] - (2 / math.pi)) < 1e-4
+    assert abs(scored[2] - (2 / math.pi)) < 1e-4
+    assert abs(scored[3] == (27 / 25) * (math.pi / 2)) < 1e-4
 
 if __name__ == "__main__":
     root = Path(os.getcwd()) / Path("test-resources/")


### PR DESCRIPTION
This PR adds a reasonably efficient implementation of the [Reock compactness score](https://en.wikipedia.org/wiki/Reock_degree_of_compactness) (node filtering and convex hull-related optimizations suggested by @apizzimenti) that uses OpenCV's [`minEnclosingCircle`](https://docs.opencv.org/3.4/d3/dc0/group__imgproc__shape.html#ga8ce13c24081bbc7151e9326f412190f1) to do the heavy lifting.