### PR TITLE
JSONtoObject renaming not reflected in all use cases; add missing install and develop dependencies.

### DIFF
--- a/docs/utilities/JSON.html
+++ b/docs/utilities/JSON.html
@@ -96,7 +96,7 @@ def jsonify(location) -&gt; list:
         # First, check whether `data` is a list; if it is, deal with all the
         # plans individually and return the list.
         if type(data) is list: return [
-            JSON(
+            JSONtoObject(
                 column=p[&#34;column&#34;],
                 locator=p[&#34;locator&#34;],
                 title=p[&#34;title&#34;] if p.get(&#34;title&#34;, False) else None
@@ -105,7 +105,7 @@ def jsonify(location) -&gt; list:
         ]
 
         # Otherwise, return a singleton list with a single plan.
-        return [JSON(
+        return [JSONtoObject(
             column=data[&#34;column&#34;],
             locator=data[&#34;locator&#34;],
             title=data[&#34;title&#34;] if data.get(&#34;title&#34;, False) else None
@@ -155,7 +155,7 @@ information about districting plans.</p></div>
         # First, check whether `data` is a list; if it is, deal with all the
         # plans individually and return the list.
         if type(data) is list: return [
-            JSON(
+            JSONtoObject(
                 column=p[&#34;column&#34;],
                 locator=p[&#34;locator&#34;],
                 title=p[&#34;title&#34;] if p.get(&#34;title&#34;, False) else None
@@ -164,7 +164,7 @@ information about districting plans.</p></div>
         ]
 
         # Otherwise, return a singleton list with a single plan.
-        return [JSON(
+        return [JSONtoObject(
             column=data[&#34;column&#34;],
             locator=data[&#34;locator&#34;],
             title=data[&#34;title&#34;] if data.get(&#34;title&#34;, False) else None

--- a/docs/utilities/index.html
+++ b/docs/utilities/index.html
@@ -92,7 +92,7 @@ information about districting plans.</p></div>
         # First, check whether `data` is a list; if it is, deal with all the
         # plans individually and return the list.
         if type(data) is list: return [
-            JSON(
+            JSONtoObject(
                 column=p[&#34;column&#34;],
                 locator=p[&#34;locator&#34;],
                 title=p[&#34;title&#34;] if p.get(&#34;title&#34;, False) else None
@@ -101,7 +101,7 @@ information about districting plans.</p></div>
         ]
 
         # Otherwise, return a singleton list with a single plan.
-        return [JSON(
+        return [JSONtoObject(
             column=data[&#34;column&#34;],
             locator=data[&#34;locator&#34;],
             title=data[&#34;title&#34;] if data.get(&#34;title&#34;, False) else None

--- a/evaltools/utilities/JSON.py
+++ b/evaltools/utilities/JSON.py
@@ -68,7 +68,7 @@ def jsonify(location) -> list:
         # First, check whether `data` is a list; if it is, deal with all the
         # plans individually and return the list.
         if type(data) is list: return [
-            JSON(
+            JSONtoObject(
                 column=p["column"],
                 locator=p["locator"],
                 title=p["title"] if p.get("title", False) else None
@@ -77,7 +77,7 @@ def jsonify(location) -> list:
         ]
 
         # Otherwise, return a singleton list with a single plan.
-        return [JSON(
+        return [JSONtoObject(
             column=data["column"],
             locator=data["locator"],
             title=data["title"] if data.get("title", False) else None

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,10 @@ setup(
     description="Tools for processing and visualizing districting plans.",
     url="https://github.com/mggg/plan-evaluation-processing",
     packages=find_packages(exclude=["tests"]),
-    install_requires=requirements
+    install_requires=requirements,
+    extras_require={
+        "dev": [
+            "pdoc3"
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 requirements = [
     "pandas", "scipy", "networkx", "geopandas", "shapely", "matplotlib",
     "gerrychain", "sortedcontainers", "gurobipy", "jsonlines", "opencv-python",
-    "imageio", "us", "pydantic" 
+    "imageio", "us", "pydantic", "censusdata", "seaborn"
 ]
 
 setup(


### PR DESCRIPTION
I overlooked a small naming inconsistency which would immediately cause a `NameError` if the `evaltools.utilities.jsonify()` method were called.