### PR TITLE
Correctly name Census and ACS columns; implement more robust testing.

### DIFF
--- a/docs/data/acs.html
+++ b/docs/data/acs.html
@@ -112,7 +112,7 @@ def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
 
     return data
 
-def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP19&#34;) -&gt; pd.DataFrame:
+def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP&#34;) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
     Retrieves ACS 5-year population estimates for the provided state, geometry
     level, and year. Geometries are from the **2010 Census**. Also retrieves
@@ -130,21 +130,24 @@ def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWV
             of columns including total populations by race and ethnicity and voting-age
             populations by race and ethnicity are returned, along with a GEOID
             column.
+        white (str, optional): The column removed from totals when calculating
+            POC populations.
 
     Returns:
         A DataFrame containing the formatted data.
     &#34;&#34;&#34;
     # Columns for total populations.
+    yearsuffix = str(year)[-2:]
     popcolumns = {
-        &#34;B01001_001E&#34;: &#34;TOTPOP19&#34;,
-        &#34;B03002_003E&#34;: &#34;WHITE19&#34;,
-        &#34;B03002_004E&#34;: &#34;BLACK19&#34;,
-        &#34;B03002_005E&#34;: &#34;AMIN19&#34;,
-        &#34;B03002_006E&#34;: &#34;ASIAN19&#34;,
-        &#34;B03002_007E&#34;: &#34;NHPI19&#34;,
-        &#34;B03002_008E&#34;: &#34;OTH19&#34;,
-        &#34;B03002_009E&#34;: &#34;2MORE19&#34;,
-        &#34;B03002_002E&#34;: &#34;NHISP19&#34;,
+        &#34;B01001_001E&#34;: &#34;TOTPOP&#34; + yearsuffix,
+        &#34;B03002_003E&#34;: &#34;WHITE&#34; + yearsuffix,
+        &#34;B03002_004E&#34;: &#34;BLACK&#34; + yearsuffix,
+        &#34;B03002_005E&#34;: &#34;AMIN&#34; + yearsuffix,
+        &#34;B03002_006E&#34;: &#34;ASIAN&#34; + yearsuffix,
+        &#34;B03002_007E&#34;: &#34;NHPI&#34; + yearsuffix,
+        &#34;B03002_008E&#34;: &#34;OTH&#34; + yearsuffix,
+        &#34;B03002_009E&#34;: &#34;2MORE&#34; + yearsuffix,
+        &#34;B03002_002E&#34;: &#34;NHISP&#34; + yearsuffix,
     }
 
     # Create a dictionary of column groups.
@@ -153,40 +156,42 @@ def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWV
     # Get VAP columns. The columns listed here are by race, irrespective of ethnicity;
     # for example, WVAP19 is the group of people who identified White as their *only*
     # race, including people who identified as Hispanic and White.
-    vap_tables = list(zip(
-        [
-            &#34;WVAP19&#34;, &#34;BVAP19&#34;, &#34;AMINVAP19&#34;, &#34;ASIANVAP19&#34;, &#34;NHPIVAP19&#34;, &#34;OTHVAP19&#34;,
-            &#34;2MOREVAP19&#34;, &#34;NHWVAP19&#34;, &#34;HVAP19&#34;
-        ],
+    vapnames = [
+        &#34;WVAP&#34;, &#34;BVAP&#34;, &#34;AMINVAP&#34;, &#34;ASIANVAP&#34;, &#34;NHPIVAP&#34;, &#34;OTHVAP&#34;, &#34;2MOREVAP&#34;,
+        &#34;NHWVAP&#34;, &#34;HVAP&#34;
+    ]
+    vaptables = list(zip(
+        [column + yearsuffix for column in vapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
-        column: variables(f&#34;B01001{table}&#34;, 7, 16) + variables(f&#34;B01001{table}&#34;, 22, 31)
-        for column, table in vap_tables
+        column: _variables(f&#34;B01001{table}&#34;, 7, 16) + _variables(f&#34;B01001{table}&#34;, 22, 31)
+        for column, table in vaptables
     })
 
     # Get CVAP columns; the same goes for these columns as does the above, except
     # these columns are 18 years and older *and* citizens.
-    cvap_tables = list(zip(
-        [
-            &#34;WCVAP19&#34;, &#34;BCVAP19&#34;, &#34;AMINCVAP19&#34;, &#34;ASIANCVAP19&#34;, &#34;NHPICVAP19&#34;, &#34;OTHCVAP19&#34;,
-            &#34;2MORECVAP19&#34;, &#34;NHWCVAP19&#34;, &#34;HCVAP19&#34;
-        ],
+    cvapnames = [
+        &#34;WCVAP&#34;, &#34;BCVAP&#34;, &#34;AMINCVAP&#34;, &#34;ASIANCVAP&#34;, &#34;NHPICVAP&#34;, &#34;OTHCVAP&#34;,
+        &#34;2MORECVAP&#34;, &#34;NHWCVAP&#34;, &#34;HCVAP&#34;
+    ]
+    cvaptables = list(zip(
+        [name + yearsuffix for name in cvapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
         column: 
-            variables(f&#34;B05003{table}&#34;, 9, 9) + variables(f&#34;B05003{table}&#34;, 11, 11) + # men
-            variables(f&#34;B05003{table}&#34;, 20, 20) + variables(f&#34;B05003{table}&#34;, 22, 22) # women
-        for column, table in cvap_tables
+            _variables(f&#34;B05003{table}&#34;, 9, 9) + _variables(f&#34;B05003{table}&#34;, 11, 11) + # men
+            _variables(f&#34;B05003{table}&#34;, 20, 20) + _variables(f&#34;B05003{table}&#34;, 22, 22) # women
+        for column, table in cvaptables
     })
     
     # Get all voting-age people and citizen voting-age people.
-    groups[&#34;VAP19&#34;] = variables(&#34;B01001&#34;, 7, 25) + variables(&#34;B01001&#34;, 31, 49)
-    groups[&#34;CVAP19&#34;] = variables(f&#34;B05003&#34;, 9, 9) + \
-        variables(f&#34;B05003&#34;, 11, 11) + \
-        variables(f&#34;B05003&#34;, 20, 20) + \
-        variables(f&#34;B05003&#34;, 22, 22)
+    groups[&#34;VAP&#34; + yearsuffix] = _variables(&#34;B01001&#34;, 7, 25) + _variables(&#34;B01001&#34;, 31, 49)
+    groups[&#34;CVAP&#34; + yearsuffix] = _variables(f&#34;B05003&#34;, 9, 9) + \
+        _variables(f&#34;B05003&#34;, 11, 11) + \
+        _variables(f&#34;B05003&#34;, 20, 20) + \
+        _variables(f&#34;B05003&#34;, 22, 22)
 
     # TODO: all variables used across the data submodule should be packaged up
     # as a class, so we can access individual dictionaries of variables to add.
@@ -217,10 +222,10 @@ def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWV
         data = data.drop(group, axis=1)
 
     # Create a POCVAP column.
-    data[&#34;POCVAP19&#34;] = data[&#34;VAP19&#34;] - data[white]
+    data[&#34;POCVAP&#34; + yearsuffix] = data[&#34;VAP&#34; + yearsuffix] - data[white + yearsuffix]
     return data
 
-def variables(prefix, start, stop, suffix=&#34;E&#34;) -&gt; list:
+def _variables(prefix, start, stop, suffix=&#34;E&#34;) -&gt; list:
     &#34;&#34;&#34;
     Returns the ACS variable names from the provided prefix, start, stop, and
     suffix parameters. Used to generate batches of names, especially for things
@@ -274,7 +279,7 @@ def _raw(geometry) -&gt; pd.DataFrame:
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="evaltools.data.acs.acs5"><code class="name flex">
-<span>def <span class="ident">acs5</span></span>(<span>state, geometry='tract', year=2019, columns=[], white='NHWVAP19') ‑> pandas.core.frame.DataFrame</span>
+<span>def <span class="ident">acs5</span></span>(<span>state, geometry='tract', year=2019, columns=[], white='NHWVAP') ‑> pandas.core.frame.DataFrame</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Retrieves ACS 5-year population estimates for the provided state, geometry
@@ -297,6 +302,9 @@ Acceptable values are <code>"tract"</code> and <code>"block group"</code>. Defau
 of columns including total populations by race and ethnicity and voting-age
 populations by race and ethnicity are returned, along with a GEOID
 column.</dd>
+<dt><strong><code>white</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>The column removed from totals when calculating
+POC populations.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <p>A DataFrame containing the formatted data.</p></div>
@@ -304,7 +312,7 @@ column.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP19&#34;) -&gt; pd.DataFrame:
+<pre><code class="python">def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP&#34;) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
     Retrieves ACS 5-year population estimates for the provided state, geometry
     level, and year. Geometries are from the **2010 Census**. Also retrieves
@@ -322,21 +330,24 @@ column.</dd>
             of columns including total populations by race and ethnicity and voting-age
             populations by race and ethnicity are returned, along with a GEOID
             column.
+        white (str, optional): The column removed from totals when calculating
+            POC populations.
 
     Returns:
         A DataFrame containing the formatted data.
     &#34;&#34;&#34;
     # Columns for total populations.
+    yearsuffix = str(year)[-2:]
     popcolumns = {
-        &#34;B01001_001E&#34;: &#34;TOTPOP19&#34;,
-        &#34;B03002_003E&#34;: &#34;WHITE19&#34;,
-        &#34;B03002_004E&#34;: &#34;BLACK19&#34;,
-        &#34;B03002_005E&#34;: &#34;AMIN19&#34;,
-        &#34;B03002_006E&#34;: &#34;ASIAN19&#34;,
-        &#34;B03002_007E&#34;: &#34;NHPI19&#34;,
-        &#34;B03002_008E&#34;: &#34;OTH19&#34;,
-        &#34;B03002_009E&#34;: &#34;2MORE19&#34;,
-        &#34;B03002_002E&#34;: &#34;NHISP19&#34;,
+        &#34;B01001_001E&#34;: &#34;TOTPOP&#34; + yearsuffix,
+        &#34;B03002_003E&#34;: &#34;WHITE&#34; + yearsuffix,
+        &#34;B03002_004E&#34;: &#34;BLACK&#34; + yearsuffix,
+        &#34;B03002_005E&#34;: &#34;AMIN&#34; + yearsuffix,
+        &#34;B03002_006E&#34;: &#34;ASIAN&#34; + yearsuffix,
+        &#34;B03002_007E&#34;: &#34;NHPI&#34; + yearsuffix,
+        &#34;B03002_008E&#34;: &#34;OTH&#34; + yearsuffix,
+        &#34;B03002_009E&#34;: &#34;2MORE&#34; + yearsuffix,
+        &#34;B03002_002E&#34;: &#34;NHISP&#34; + yearsuffix,
     }
 
     # Create a dictionary of column groups.
@@ -345,40 +356,42 @@ column.</dd>
     # Get VAP columns. The columns listed here are by race, irrespective of ethnicity;
     # for example, WVAP19 is the group of people who identified White as their *only*
     # race, including people who identified as Hispanic and White.
-    vap_tables = list(zip(
-        [
-            &#34;WVAP19&#34;, &#34;BVAP19&#34;, &#34;AMINVAP19&#34;, &#34;ASIANVAP19&#34;, &#34;NHPIVAP19&#34;, &#34;OTHVAP19&#34;,
-            &#34;2MOREVAP19&#34;, &#34;NHWVAP19&#34;, &#34;HVAP19&#34;
-        ],
+    vapnames = [
+        &#34;WVAP&#34;, &#34;BVAP&#34;, &#34;AMINVAP&#34;, &#34;ASIANVAP&#34;, &#34;NHPIVAP&#34;, &#34;OTHVAP&#34;, &#34;2MOREVAP&#34;,
+        &#34;NHWVAP&#34;, &#34;HVAP&#34;
+    ]
+    vaptables = list(zip(
+        [column + yearsuffix for column in vapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
-        column: variables(f&#34;B01001{table}&#34;, 7, 16) + variables(f&#34;B01001{table}&#34;, 22, 31)
-        for column, table in vap_tables
+        column: _variables(f&#34;B01001{table}&#34;, 7, 16) + _variables(f&#34;B01001{table}&#34;, 22, 31)
+        for column, table in vaptables
     })
 
     # Get CVAP columns; the same goes for these columns as does the above, except
     # these columns are 18 years and older *and* citizens.
-    cvap_tables = list(zip(
-        [
-            &#34;WCVAP19&#34;, &#34;BCVAP19&#34;, &#34;AMINCVAP19&#34;, &#34;ASIANCVAP19&#34;, &#34;NHPICVAP19&#34;, &#34;OTHCVAP19&#34;,
-            &#34;2MORECVAP19&#34;, &#34;NHWCVAP19&#34;, &#34;HCVAP19&#34;
-        ],
+    cvapnames = [
+        &#34;WCVAP&#34;, &#34;BCVAP&#34;, &#34;AMINCVAP&#34;, &#34;ASIANCVAP&#34;, &#34;NHPICVAP&#34;, &#34;OTHCVAP&#34;,
+        &#34;2MORECVAP&#34;, &#34;NHWCVAP&#34;, &#34;HCVAP&#34;
+    ]
+    cvaptables = list(zip(
+        [name + yearsuffix for name in cvapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
         column: 
-            variables(f&#34;B05003{table}&#34;, 9, 9) + variables(f&#34;B05003{table}&#34;, 11, 11) + # men
-            variables(f&#34;B05003{table}&#34;, 20, 20) + variables(f&#34;B05003{table}&#34;, 22, 22) # women
-        for column, table in cvap_tables
+            _variables(f&#34;B05003{table}&#34;, 9, 9) + _variables(f&#34;B05003{table}&#34;, 11, 11) + # men
+            _variables(f&#34;B05003{table}&#34;, 20, 20) + _variables(f&#34;B05003{table}&#34;, 22, 22) # women
+        for column, table in cvaptables
     })
     
     # Get all voting-age people and citizen voting-age people.
-    groups[&#34;VAP19&#34;] = variables(&#34;B01001&#34;, 7, 25) + variables(&#34;B01001&#34;, 31, 49)
-    groups[&#34;CVAP19&#34;] = variables(f&#34;B05003&#34;, 9, 9) + \
-        variables(f&#34;B05003&#34;, 11, 11) + \
-        variables(f&#34;B05003&#34;, 20, 20) + \
-        variables(f&#34;B05003&#34;, 22, 22)
+    groups[&#34;VAP&#34; + yearsuffix] = _variables(&#34;B01001&#34;, 7, 25) + _variables(&#34;B01001&#34;, 31, 49)
+    groups[&#34;CVAP&#34; + yearsuffix] = _variables(f&#34;B05003&#34;, 9, 9) + \
+        _variables(f&#34;B05003&#34;, 11, 11) + \
+        _variables(f&#34;B05003&#34;, 20, 20) + \
+        _variables(f&#34;B05003&#34;, 22, 22)
 
     # TODO: all variables used across the data submodule should be packaged up
     # as a class, so we can access individual dictionaries of variables to add.
@@ -409,7 +422,7 @@ column.</dd>
         data = data.drop(group, axis=1)
 
     # Create a POCVAP column.
-    data[&#34;POCVAP19&#34;] = data[&#34;VAP19&#34;] - data[white]
+    data[&#34;POCVAP&#34; + yearsuffix] = data[&#34;VAP&#34; + yearsuffix] - data[white + yearsuffix]
     return data</code></pre>
 </details>
 </dd>
@@ -518,65 +531,6 @@ the 2019 ACS CVAP Special Tab.</p></div>
     return data</code></pre>
 </details>
 </dd>
-<dt id="evaltools.data.acs.variables"><code class="name flex">
-<span>def <span class="ident">variables</span></span>(<span>prefix, start, stop, suffix='E') ‑> list</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Returns the ACS variable names from the provided prefix, start, stop, and
-suffix parameters. Used to generate batches of names, especially for things
-like voting-age population. Variable names are formatted like
-<code>&lt;prefix&gt;_&lt;number identifier&gt;&lt;suffix&gt;</code>, where <code>&lt;prefix&gt;</code> is a population grouping,
-<code>&lt;number identifier&gt;</code> is the number of the variable in that grouping, and
-<code>&lt;suffix&gt;</code> designates the file used. <a href="&lt;https://tinyurl.com/43ajptky&gt;&gt;">Variables are listed
-here </a>.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>prefix</code></strong> :&ensp;<code>str</code></dt>
-<dd>Population grouping; typically "B01001." These prefixes
-change based on subpopulation: for example, the prefix for Black
-age-by-sex tables is "B01001B"; for Hispanic and Latino, it is
-"B01001I."</dd>
-<dt><strong><code>start</code></strong> :&ensp;<code>int</code></dt>
-<dd>Where to start numbering.</dd>
-<dt><strong><code>stop</code></strong> :&ensp;<code>int</code></dt>
-<dd>Where to stop numbering. Inclusive.</dd>
-<dt><strong><code>suffix</code></strong> :&ensp;<code>str</code></dt>
-<dd>Suffix designating the file. For most purposes, this is "E."</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>A list of ACS5 variable names.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def variables(prefix, start, stop, suffix=&#34;E&#34;) -&gt; list:
-    &#34;&#34;&#34;
-    Returns the ACS variable names from the provided prefix, start, stop, and
-    suffix parameters. Used to generate batches of names, especially for things
-    like voting-age population. Variable names are formatted like
-    `&lt;prefix&gt;_&lt;number identifier&gt;&lt;suffix&gt;`, where `&lt;prefix&gt;` is a population grouping,
-    `&lt;number identifier&gt;` is the number of the variable in that grouping, and
-    `&lt;suffix&gt;` designates the file used. [Variables are listed
-    here ](https://tinyurl.com/43ajptky&gt;).
-
-    Args:
-        prefix (str): Population grouping; typically &#34;B01001.&#34; These prefixes
-            change based on subpopulation: for example, the prefix for Black
-            age-by-sex tables is &#34;B01001B&#34;; for Hispanic and Latino, it is
-            &#34;B01001I.&#34;
-        start (int): Where to start numbering.
-        stop (int): Where to stop numbering. Inclusive.
-        suffix (str): Suffix designating the file. For most purposes, this is &#34;E.&#34;
-
-    Returns:
-        A list of ACS5 variable names.
-    &#34;&#34;&#34;
-    return [
-        f&#34;{prefix}_{str(t).zfill(3)}{suffix}&#34;
-        for t in range(start, stop+1)
-    ]</code></pre>
-</details>
-</dd>
 </dl>
 </section>
 <section>
@@ -636,7 +590,6 @@ float: right;
 <ul class="">
 <li><code><a title="evaltools.data.acs.acs5" href="#evaltools.data.acs.acs5">acs5</a></code></li>
 <li><code><a title="evaltools.data.acs.cvap" href="#evaltools.data.acs.cvap">cvap</a></code></li>
-<li><code><a title="evaltools.data.acs.variables" href="#evaltools.data.acs.variables">variables</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/data/index.html
+++ b/docs/data/index.html
@@ -79,7 +79,7 @@ __all__ = [
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="evaltools.data.acs5"><code class="name flex">
-<span>def <span class="ident">acs5</span></span>(<span>state, geometry='tract', year=2019, columns=[], white='NHWVAP19') ‑> pandas.core.frame.DataFrame</span>
+<span>def <span class="ident">acs5</span></span>(<span>state, geometry='tract', year=2019, columns=[], white='NHWVAP') ‑> pandas.core.frame.DataFrame</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Retrieves ACS 5-year population estimates for the provided state, geometry
@@ -102,6 +102,9 @@ Acceptable values are <code>"tract"</code> and <code>"block group"</code>. Defau
 of columns including total populations by race and ethnicity and voting-age
 populations by race and ethnicity are returned, along with a GEOID
 column.</dd>
+<dt><strong><code>white</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>The column removed from totals when calculating
+POC populations.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <p>A DataFrame containing the formatted data.</p></div>
@@ -109,7 +112,7 @@ column.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP19&#34;) -&gt; pd.DataFrame:
+<pre><code class="python">def acs5(state, geometry=&#34;tract&#34;, year=2019, columns=[], white=&#34;NHWVAP&#34;) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
     Retrieves ACS 5-year population estimates for the provided state, geometry
     level, and year. Geometries are from the **2010 Census**. Also retrieves
@@ -127,21 +130,24 @@ column.</dd>
             of columns including total populations by race and ethnicity and voting-age
             populations by race and ethnicity are returned, along with a GEOID
             column.
+        white (str, optional): The column removed from totals when calculating
+            POC populations.
 
     Returns:
         A DataFrame containing the formatted data.
     &#34;&#34;&#34;
     # Columns for total populations.
+    yearsuffix = str(year)[-2:]
     popcolumns = {
-        &#34;B01001_001E&#34;: &#34;TOTPOP19&#34;,
-        &#34;B03002_003E&#34;: &#34;WHITE19&#34;,
-        &#34;B03002_004E&#34;: &#34;BLACK19&#34;,
-        &#34;B03002_005E&#34;: &#34;AMIN19&#34;,
-        &#34;B03002_006E&#34;: &#34;ASIAN19&#34;,
-        &#34;B03002_007E&#34;: &#34;NHPI19&#34;,
-        &#34;B03002_008E&#34;: &#34;OTH19&#34;,
-        &#34;B03002_009E&#34;: &#34;2MORE19&#34;,
-        &#34;B03002_002E&#34;: &#34;NHISP19&#34;,
+        &#34;B01001_001E&#34;: &#34;TOTPOP&#34; + yearsuffix,
+        &#34;B03002_003E&#34;: &#34;WHITE&#34; + yearsuffix,
+        &#34;B03002_004E&#34;: &#34;BLACK&#34; + yearsuffix,
+        &#34;B03002_005E&#34;: &#34;AMIN&#34; + yearsuffix,
+        &#34;B03002_006E&#34;: &#34;ASIAN&#34; + yearsuffix,
+        &#34;B03002_007E&#34;: &#34;NHPI&#34; + yearsuffix,
+        &#34;B03002_008E&#34;: &#34;OTH&#34; + yearsuffix,
+        &#34;B03002_009E&#34;: &#34;2MORE&#34; + yearsuffix,
+        &#34;B03002_002E&#34;: &#34;NHISP&#34; + yearsuffix,
     }
 
     # Create a dictionary of column groups.
@@ -150,40 +156,42 @@ column.</dd>
     # Get VAP columns. The columns listed here are by race, irrespective of ethnicity;
     # for example, WVAP19 is the group of people who identified White as their *only*
     # race, including people who identified as Hispanic and White.
-    vap_tables = list(zip(
-        [
-            &#34;WVAP19&#34;, &#34;BVAP19&#34;, &#34;AMINVAP19&#34;, &#34;ASIANVAP19&#34;, &#34;NHPIVAP19&#34;, &#34;OTHVAP19&#34;,
-            &#34;2MOREVAP19&#34;, &#34;NHWVAP19&#34;, &#34;HVAP19&#34;
-        ],
+    vapnames = [
+        &#34;WVAP&#34;, &#34;BVAP&#34;, &#34;AMINVAP&#34;, &#34;ASIANVAP&#34;, &#34;NHPIVAP&#34;, &#34;OTHVAP&#34;, &#34;2MOREVAP&#34;,
+        &#34;NHWVAP&#34;, &#34;HVAP&#34;
+    ]
+    vaptables = list(zip(
+        [column + yearsuffix for column in vapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
-        column: variables(f&#34;B01001{table}&#34;, 7, 16) + variables(f&#34;B01001{table}&#34;, 22, 31)
-        for column, table in vap_tables
+        column: _variables(f&#34;B01001{table}&#34;, 7, 16) + _variables(f&#34;B01001{table}&#34;, 22, 31)
+        for column, table in vaptables
     })
 
     # Get CVAP columns; the same goes for these columns as does the above, except
     # these columns are 18 years and older *and* citizens.
-    cvap_tables = list(zip(
-        [
-            &#34;WCVAP19&#34;, &#34;BCVAP19&#34;, &#34;AMINCVAP19&#34;, &#34;ASIANCVAP19&#34;, &#34;NHPICVAP19&#34;, &#34;OTHCVAP19&#34;,
-            &#34;2MORECVAP19&#34;, &#34;NHWCVAP19&#34;, &#34;HCVAP19&#34;
-        ],
+    cvapnames = [
+        &#34;WCVAP&#34;, &#34;BCVAP&#34;, &#34;AMINCVAP&#34;, &#34;ASIANCVAP&#34;, &#34;NHPICVAP&#34;, &#34;OTHCVAP&#34;,
+        &#34;2MORECVAP&#34;, &#34;NHWCVAP&#34;, &#34;HCVAP&#34;
+    ]
+    cvaptables = list(zip(
+        [name + yearsuffix for name in cvapnames],
         [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;, &#34;D&#34;, &#34;E&#34;, &#34;F&#34;, &#34;G&#34;, &#34;H&#34;, &#34;I&#34;]
     ))
     groups.update({
         column: 
-            variables(f&#34;B05003{table}&#34;, 9, 9) + variables(f&#34;B05003{table}&#34;, 11, 11) + # men
-            variables(f&#34;B05003{table}&#34;, 20, 20) + variables(f&#34;B05003{table}&#34;, 22, 22) # women
-        for column, table in cvap_tables
+            _variables(f&#34;B05003{table}&#34;, 9, 9) + _variables(f&#34;B05003{table}&#34;, 11, 11) + # men
+            _variables(f&#34;B05003{table}&#34;, 20, 20) + _variables(f&#34;B05003{table}&#34;, 22, 22) # women
+        for column, table in cvaptables
     })
     
     # Get all voting-age people and citizen voting-age people.
-    groups[&#34;VAP19&#34;] = variables(&#34;B01001&#34;, 7, 25) + variables(&#34;B01001&#34;, 31, 49)
-    groups[&#34;CVAP19&#34;] = variables(f&#34;B05003&#34;, 9, 9) + \
-        variables(f&#34;B05003&#34;, 11, 11) + \
-        variables(f&#34;B05003&#34;, 20, 20) + \
-        variables(f&#34;B05003&#34;, 22, 22)
+    groups[&#34;VAP&#34; + yearsuffix] = _variables(&#34;B01001&#34;, 7, 25) + _variables(&#34;B01001&#34;, 31, 49)
+    groups[&#34;CVAP&#34; + yearsuffix] = _variables(f&#34;B05003&#34;, 9, 9) + \
+        _variables(f&#34;B05003&#34;, 11, 11) + \
+        _variables(f&#34;B05003&#34;, 20, 20) + \
+        _variables(f&#34;B05003&#34;, 22, 22)
 
     # TODO: all variables used across the data submodule should be packaged up
     # as a class, so we can access individual dictionaries of variables to add.
@@ -214,7 +222,7 @@ column.</dd>
         data = data.drop(group, axis=1)
 
     # Create a POCVAP column.
-    data[&#34;POCVAP19&#34;] = data[&#34;VAP19&#34;] - data[white]
+    data[&#34;POCVAP&#34; + yearsuffix] = data[&#34;VAP&#34; + yearsuffix] - data[white + yearsuffix]
     return data</code></pre>
 </details>
 </dd>
@@ -239,8 +247,8 @@ implicitly protect against incorrect column names and excessive API
 calls.</dd>
 <dt><strong><code>geometry</code></strong> :&ensp;<code>string</code>, optional</dt>
 <dd>Geometry level at which we retrieve data.
-Defaults to <code>"block"</code>, to retrieve block-level data for the state
-provided.</dd>
+Defaults to <code>"block"</code> to retrieve block-level data for the state
+provided. Accepted values are <code>"block"</code>, <code>"block group</code>", and <code>"tract"</code>.</dd>
 <dt><strong><code>key</code></strong> :&ensp;<code>string</code>, optional</dt>
 <dd>Census API key.</dd>
 </dl>
@@ -269,8 +277,8 @@ designation and a <code>GEOID20</code> column for joining to geometries.</p></di
             implicitly protect against incorrect column names and excessive API
             calls.
         geometry (string, optional): Geometry level at which we retrieve data.
-            Defaults to `&#34;block&#34;`, to retrieve block-level data for the state
-            provided.
+            Defaults to `&#34;block&#34;` to retrieve block-level data for the state
+            provided. Accepted values are `&#34;block&#34;`, `&#34;block group`&#34;, and `&#34;tract&#34;`.
         key (string, optional): Census API key.
 
     Returns:
@@ -296,14 +304,14 @@ designation and a <code>GEOID20</code> column for joining to geometries.</p></di
     # Create the end part of the query string.
     q = [
         (&#34;key&#34;, key),
-        (&#34;for&#34;, f&#34;{geometry}:*&#34;),
+        (&#34;for&#34;, f&#34;{geometry.replace(&#39; &#39;, r&#39;%20&#39;)}:*&#34;),
         (&#34;in&#34;, f&#34;state:{str(state.fips).zfill(2)}&#34;),
         (&#34;in&#34;, &#34;county:*&#34;),
     ]
 
     # Based on the geometry type, add an additional entry; this is required to
     # match the Census geographic hierarchy.
-    if geometry != &#34;block&#34;: q.append((&#34;in&#34;, &#34;tract:*&#34;))
+    if geometry in {&#34;block&#34;, &#34;block group&#34;}: q.append((&#34;in&#34;, &#34;tract:*&#34;))
 
     # Now, since the Census doesn&#39;t allow us to request more than 50 variables
     # at once, we request things in two parts and then merge them together.
@@ -317,7 +325,8 @@ designation and a <code>GEOID20</code> column for joining to geometries.</p></di
         # Get the chunk of variables and create a tail of columns (geographic
         # identifiers).
         varchunk = vars[start:stop]
-        tail = [&#34;state&#34;, &#34;county&#34;, &#34;tract&#34;] + ([&#34;block&#34;] if geometry == &#34;block&#34; else [])
+        last = [geometry] if geometry in {&#34;block group&#34;, &#34;block&#34;} else []
+        tail = [&#34;state&#34;, &#34;county&#34;, &#34;tract&#34;] + last
 
         # Create an unescaped query string.
         unescaped = q.copy()
@@ -338,9 +347,15 @@ designation and a <code>GEOID20</code> column for joining to geometries.</p></di
         chunk = chunk.drop(tail, axis=1)
         mergeable.append(chunk)
 
-    # Merge the dataframes and rename.
+    # Merge the dataframes, rename everything, make the columns ints, and return.
     merged = reduce(lambda l, r: pd.merge(l, r, on=&#34;GEOID20&#34;), mergeable)
-    return merged.rename(varmap, axis=1)</code></pre>
+    merged = merged.rename(varmap, axis=1)
+    merged = merged.astype({var: int for var in varmap.values()})
+
+    # Make the GEOID20 column the first column.
+    merged = merged[[&#34;GEOID20&#34;] + list(varmap.values())]
+
+    return merged</code></pre>
 </details>
 </dd>
 <dt id="evaltools.data.csvs"><code class="name flex">
@@ -870,12 +885,12 @@ P4</a>.</p>
     # to get the total Hispanic population and the total population.
     if table in {&#34;P2&#34;, &#34;P4&#34;}:
         numbers = [1, 2] + numbers
-        hcol = &#34;HVAP20&#34; if table == &#34;P4&#34; else &#34;HISP20&#34;
+        hcol = &#34;HVAP20&#34; if table == &#34;P4&#34; else &#34;HPOP20&#34;
         tcol = &#34;VAP20&#34; if table == &#34;P4&#34; else &#34;TOTPOP20&#34;
         combos = [tcol, hcol] + combos
     else:
         numbers = [1] + numbers
-        tcol = &#34;VAP20&#34; if table == &#34;P4&#34; else &#34;TOTPOP20&#34;
+        tcol = &#34;VAP20&#34; if table in {&#34;P3&#34;, &#34;P4&#34;} else &#34;TOTPOP20&#34;
         combos = [tcol] + combos
     
     # Create the variable names and zip the names together with the combinations.

--- a/evaltools/data/acs.py
+++ b/evaltools/data/acs.py
@@ -84,7 +84,7 @@ def cvap(state, geometry="tract") -> pd.DataFrame:
 
     return data
 
-def acs5(state, geometry="tract", year=2019, columns=[], white="NHWVAP19") -> pd.DataFrame:
+def acs5(state, geometry="tract", year=2019, columns=[], white="NHWVAP") -> pd.DataFrame:
     """
     Retrieves ACS 5-year population estimates for the provided state, geometry
     level, and year. Geometries are from the **2010 Census**. Also retrieves
@@ -102,21 +102,24 @@ def acs5(state, geometry="tract", year=2019, columns=[], white="NHWVAP19") -> pd
             of columns including total populations by race and ethnicity and voting-age
             populations by race and ethnicity are returned, along with a GEOID
             column.
+        white (str, optional): The column removed from totals when calculating
+            POC populations.
 
     Returns:
         A DataFrame containing the formatted data.
     """
     # Columns for total populations.
+    yearsuffix = str(year)[-2:]
     popcolumns = {
-        "B01001_001E": "TOTPOP19",
-        "B03002_003E": "WHITE19",
-        "B03002_004E": "BLACK19",
-        "B03002_005E": "AMIN19",
-        "B03002_006E": "ASIAN19",
-        "B03002_007E": "NHPI19",
-        "B03002_008E": "OTH19",
-        "B03002_009E": "2MORE19",
-        "B03002_002E": "NHISP19",
+        "B01001_001E": "TOTPOP" + yearsuffix,
+        "B03002_003E": "WHITE" + yearsuffix,
+        "B03002_004E": "BLACK" + yearsuffix,
+        "B03002_005E": "AMIN" + yearsuffix,
+        "B03002_006E": "ASIAN" + yearsuffix,
+        "B03002_007E": "NHPI" + yearsuffix,
+        "B03002_008E": "OTH" + yearsuffix,
+        "B03002_009E": "2MORE" + yearsuffix,
+        "B03002_002E": "NHISP" + yearsuffix,
     }
 
     # Create a dictionary of column groups.
@@ -125,40 +128,42 @@ def acs5(state, geometry="tract", year=2019, columns=[], white="NHWVAP19") -> pd
     # Get VAP columns. The columns listed here are by race, irrespective of ethnicity;
     # for example, WVAP19 is the group of people who identified White as their *only*
     # race, including people who identified as Hispanic and White.
-    vap_tables = list(zip(
-        [
-            "WVAP19", "BVAP19", "AMINVAP19", "ASIANVAP19", "NHPIVAP19", "OTHVAP19",
-            "2MOREVAP19", "NHWVAP19", "HVAP19"
-        ],
+    vapnames = [
+        "WVAP", "BVAP", "AMINVAP", "ASIANVAP", "NHPIVAP", "OTHVAP", "2MOREVAP",
+        "NHWVAP", "HVAP"
+    ]
+    vaptables = list(zip(
+        [column + yearsuffix for column in vapnames],
         ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
     ))
     groups.update({
-        column: variables(f"B01001{table}", 7, 16) + variables(f"B01001{table}", 22, 31)
-        for column, table in vap_tables
+        column: _variables(f"B01001{table}", 7, 16) + _variables(f"B01001{table}", 22, 31)
+        for column, table in vaptables
     })
 
     # Get CVAP columns; the same goes for these columns as does the above, except
     # these columns are 18 years and older *and* citizens.
-    cvap_tables = list(zip(
-        [
-            "WCVAP19", "BCVAP19", "AMINCVAP19", "ASIANCVAP19", "NHPICVAP19", "OTHCVAP19",
-            "2MORECVAP19", "NHWCVAP19", "HCVAP19"
-        ],
+    cvapnames = [
+        "WCVAP", "BCVAP", "AMINCVAP", "ASIANCVAP", "NHPICVAP", "OTHCVAP",
+        "2MORECVAP", "NHWCVAP", "HCVAP"
+    ]
+    cvaptables = list(zip(
+        [name + yearsuffix for name in cvapnames],
         ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
     ))
     groups.update({
         column: 
-            variables(f"B05003{table}", 9, 9) + variables(f"B05003{table}", 11, 11) + # men
-            variables(f"B05003{table}", 20, 20) + variables(f"B05003{table}", 22, 22) # women
-        for column, table in cvap_tables
+            _variables(f"B05003{table}", 9, 9) + _variables(f"B05003{table}", 11, 11) + # men
+            _variables(f"B05003{table}", 20, 20) + _variables(f"B05003{table}", 22, 22) # women
+        for column, table in cvaptables
     })
     
     # Get all voting-age people and citizen voting-age people.
-    groups["VAP19"] = variables("B01001", 7, 25) + variables("B01001", 31, 49)
-    groups["CVAP19"] = variables(f"B05003", 9, 9) + \
-        variables(f"B05003", 11, 11) + \
-        variables(f"B05003", 20, 20) + \
-        variables(f"B05003", 22, 22)
+    groups["VAP" + yearsuffix] = _variables("B01001", 7, 25) + _variables("B01001", 31, 49)
+    groups["CVAP" + yearsuffix] = _variables(f"B05003", 9, 9) + \
+        _variables(f"B05003", 11, 11) + \
+        _variables(f"B05003", 20, 20) + \
+        _variables(f"B05003", 22, 22)
 
     # TODO: all variables used across the data submodule should be packaged up
     # as a class, so we can access individual dictionaries of variables to add.
@@ -189,10 +194,10 @@ def acs5(state, geometry="tract", year=2019, columns=[], white="NHWVAP19") -> pd
         data = data.drop(group, axis=1)
 
     # Create a POCVAP column.
-    data["POCVAP19"] = data["VAP19"] - data[white]
+    data["POCVAP" + yearsuffix] = data["VAP" + yearsuffix] - data[white + yearsuffix]
     return data
 
-def variables(prefix, start, stop, suffix="E") -> list:
+def _variables(prefix, start, stop, suffix="E") -> list:
     """
     Returns the ACS variable names from the provided prefix, start, stop, and
     suffix parameters. Used to generate batches of names, especially for things

--- a/evaltools/data/census.py
+++ b/evaltools/data/census.py
@@ -112,6 +112,10 @@ def census(
     merged = reduce(lambda l, r: pd.merge(l, r, on="GEOID20"), mergeable)
     merged = merged.rename(varmap, axis=1)
     merged = merged.astype({var: int for var in varmap.values()})
+
+    # Make the GEOID20 column the first column.
+    merged = merged[["GEOID20"] + list(varmap.values())]
+
     return merged
 
 

--- a/evaltools/data/census.py
+++ b/evaltools/data/census.py
@@ -65,14 +65,14 @@ def census(
     # Create the end part of the query string.
     q = [
         ("key", key),
-        ("for", f"{geometry}:*"),
+        ("for", f"{geometry.replace(' ', r'%20')}:*"),
         ("in", f"state:{str(state.fips).zfill(2)}"),
         ("in", "county:*"),
     ]
 
     # Based on the geometry type, add an additional entry; this is required to
     # match the Census geographic hierarchy.
-    if geometry != "block": q.append(("in", "tract:*"))
+    if geometry in {"block", "block group"}: q.append(("in", "tract:*"))
 
     # Now, since the Census doesn't allow us to request more than 50 variables
     # at once, we request things in two parts and then merge them together.
@@ -86,7 +86,8 @@ def census(
         # Get the chunk of variables and create a tail of columns (geographic
         # identifiers).
         varchunk = vars[start:stop]
-        tail = ["state", "county", "tract"] + (["block"] if geometry == "block" else [])
+        last = [geometry] if geometry in {"block group", "block"} else []
+        tail = ["state", "county", "tract"] + last
 
         # Create an unescaped query string.
         unescaped = q.copy()
@@ -107,9 +108,11 @@ def census(
         chunk = chunk.drop(tail, axis=1)
         mergeable.append(chunk)
 
-    # Merge the dataframes and rename.
+    # Merge the dataframes, rename everything, make the columns ints, and return.
     merged = reduce(lambda l, r: pd.merge(l, r, on="GEOID20"), mergeable)
-    return merged.rename(varmap, axis=1)
+    merged = merged.rename(varmap, axis=1)
+    merged = merged.astype({var: int for var in varmap.values()})
+    return merged
 
 
 def variables(table) -> dict:
@@ -157,12 +160,12 @@ def variables(table) -> dict:
     # to get the total Hispanic population and the total population.
     if table in {"P2", "P4"}:
         numbers = [1, 2] + numbers
-        hcol = "HVAP20" if table == "P4" else "HISP20"
+        hcol = "HVAP20" if table == "P4" else "HPOP20"
         tcol = "VAP20" if table == "P4" else "TOTPOP20"
         combos = [tcol, hcol] + combos
     else:
         numbers = [1] + numbers
-        tcol = "VAP20" if table == "P4" else "TOTPOP20"
+        tcol = "VAP20" if table in {"P3", "P4"} else "TOTPOP20"
         combos = [tcol] + combos
     
     # Create the variable names and zip the names together with the combinations.

--- a/evaltools/data/census.py
+++ b/evaltools/data/census.py
@@ -38,8 +38,8 @@ def census(
             implicitly protect against incorrect column names and excessive API
             calls.
         geometry (string, optional): Geometry level at which we retrieve data.
-            Defaults to `"block"`, to retrieve block-level data for the state
-            provided.
+            Defaults to `"block"` to retrieve block-level data for the state
+            provided. Accepted values are `"block"`, `"block group`", and `"tract"`.
         key (string, optional): Census API key.
 
     Returns:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -103,35 +103,111 @@ def test_acs5_bgs():
 
 
 def test_census_tracts():
+    # Get a test set of data on Alabama.
     AL = us.states.AL
-    original = census(AL, geometry="tract", table="P4")
-    columns = {"GEOID20"} | set(variables("P4").values())
     tracts = 1437
-
-    assert len(original) == tracts
-    assert set(list(original)) == columns
-    
-    # Download additional variables and verify whether they match appropriately.
-    data = census(AL, table="P2", columns={"P2_003N": "NHISP"}, geometry="tract")
-    columns = {"GEOID20", "NHISP"}
-
-    assert len(data) == tracts
-    assert set(list(data)) == columns
-
-    # Now download *more* additional data and verify whether they match
-    # appropriately.
-    vars = variables("P3")
-    varnames = {
-        var: name
-        for var, name in vars.items() if "WHITE" in name or "BLACK" in name
+    tests = {
+        "P1": [
+            ("TOTPOP20", 5024279),
+            ("WHITEASIANPOP20", 18510)
+        ],
+        "P2": [
+            ("NHWHITEAMINASIANPOP20", 821),
+            ("HPOP20", 264047)
+        ],
+        "P3": [
+            ("WHITEASIANOTHVAP20", 201),
+            ("VAP20", 3917166)
+        ],
+        "P4": [
+            ("NHBLACKASIANOTHVAP20", 31),
+            ("HVAP20", 166856)
+        ]
     }
-    columns = {"GEOID20"} | set(varnames.values())
 
-    # Get the data.
-    data = census(AL, table="P3", columns=varnames, geometry="tract")
+    # Get the data for each table and verify that the values are correct.
+    for table, cases in tests.items():
+        data = census(AL, table=table, geometry="tract")
+        columns = set(variables(table).values()) | {"GEOID20"}
+        
+        # Assert we have the correct number of values and the correct columns.
+        assert len(data) == tracts
+        assert set(list(data)) == columns
 
-    assert len(data) == tracts
-    assert set(list(data)) == columns
+        # For each test case, confirm that we have the correct sum.
+        for column, correct in cases: assert data[column].sum() == correct
+
+
+def test_census_bgs():
+    # Get a test set of data on Alabama.
+    AL = us.states.AL
+    bgs = 3925
+    tests = {
+        "P1": [
+            ("TOTPOP20", 5024279),
+            ("WHITEASIANPOP20", 18510)
+        ],
+        "P2": [
+            ("NHWHITEAMINASIANPOP20", 821),
+            ("HPOP20", 264047)
+        ],
+        "P3": [
+            ("WHITEASIANOTHVAP20", 201),
+            ("VAP20", 3917166)
+        ],
+        "P4": [
+            ("NHBLACKASIANOTHVAP20", 31),
+            ("HVAP20", 166856)
+        ]
+    }
+
+    # Get the data for each table and verify that the values are correct.
+    for table, cases in tests.items():
+        data = census(AL, table=table, geometry="block group")
+        columns = set(variables(table).values()) | {"GEOID20"}
+        
+        # Assert we have the correct number of values and the correct columns.
+        assert len(data) == bgs
+        assert set(list(data)) == columns
+
+        # For each test case, confirm that we have the correct sum.
+        for column, correct in cases: assert data[column].sum() == correct
+
+
+def test_census_blocks():
+    AL = us.states.AL
+    blocks = 185976
+
+    tests = {
+        "P1": [
+            ("TOTPOP20", 5024279),
+            ("WHITEASIANPOP20", 18510)
+        ],
+        "P2": [
+            ("NHWHITEAMINASIANPOP20", 821),
+            ("HPOP20", 264047)
+        ],
+        "P3": [
+            ("WHITEASIANOTHVAP20", 201),
+            ("VAP20", 3917166)
+        ],
+        "P4": [
+            ("NHBLACKASIANOTHVAP20", 31),
+            ("HVAP20", 166856)
+        ]
+    }
+
+    # Get the data for each table and verify that the values are correct.
+    for table, cases in tests.items():
+        data = census(AL, table=table, geometry="block")
+        columns = set(variables(table).values()) | {"GEOID20"}
+        
+        # Assert we have the correct number of values and the correct columns.
+        assert len(data) == blocks
+        assert set(list(data)) == columns
+
+        # For each test case, confirm that we have the correct sum.
+        for column, correct in cases: assert data[column].sum() == correct
 
 def test_assignmentcompressor_compress():
     # Get the GEOIDs from the blocks.
@@ -303,5 +379,5 @@ def test_remap():
     plans = remap(plans, unitmaps)
 
 if __name__ == "__main__":
-    test_acs5_tracts()
+    test_census_tracts()
  

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -102,31 +102,38 @@ def test_acs5_bgs():
     assert set(list(data)) == columns
 
 
+# These test statistics are taken from the Alabama 2020 PL94-171 P1 through P4
+# tables from the Census Data Explorer (https://data.census.gov/cedsci/). We then
+# use the `census()` method to retrieve Alabama 2020 PL94-171 at all three levels
+# of geography, checking that the columns on the data and the columns below sum
+# to the same values.
+CENSUSTESTDATA = {
+    "P1": [
+        ("TOTPOP20", 5024279),
+        ("WHITEASIANPOP20", 18510)
+    ],
+    "P2": [
+        ("NHWHITEAMINASIANPOP20", 821),
+        ("HPOP20", 264047)
+    ],
+    "P3": [
+        ("WHITEASIANOTHVAP20", 201),
+        ("VAP20", 3917166)
+    ],
+    "P4": [
+        ("NHBLACKASIANOTHVAP20", 31),
+        ("HVAP20", 166856)
+    ]
+}
+
+
 def test_census_tracts():
     # Get a test set of data on Alabama.
     AL = us.states.AL
     tracts = 1437
-    tests = {
-        "P1": [
-            ("TOTPOP20", 5024279),
-            ("WHITEASIANPOP20", 18510)
-        ],
-        "P2": [
-            ("NHWHITEAMINASIANPOP20", 821),
-            ("HPOP20", 264047)
-        ],
-        "P3": [
-            ("WHITEASIANOTHVAP20", 201),
-            ("VAP20", 3917166)
-        ],
-        "P4": [
-            ("NHBLACKASIANOTHVAP20", 31),
-            ("HVAP20", 166856)
-        ]
-    }
 
     # Get the data for each table and verify that the values are correct.
-    for table, cases in tests.items():
+    for table, cases in CENSUSTESTDATA.items():
         data = census(AL, table=table, geometry="tract")
         columns = set(variables(table).values()) | {"GEOID20"}
         
@@ -142,27 +149,9 @@ def test_census_bgs():
     # Get a test set of data on Alabama.
     AL = us.states.AL
     bgs = 3925
-    tests = {
-        "P1": [
-            ("TOTPOP20", 5024279),
-            ("WHITEASIANPOP20", 18510)
-        ],
-        "P2": [
-            ("NHWHITEAMINASIANPOP20", 821),
-            ("HPOP20", 264047)
-        ],
-        "P3": [
-            ("WHITEASIANOTHVAP20", 201),
-            ("VAP20", 3917166)
-        ],
-        "P4": [
-            ("NHBLACKASIANOTHVAP20", 31),
-            ("HVAP20", 166856)
-        ]
-    }
 
     # Get the data for each table and verify that the values are correct.
-    for table, cases in tests.items():
+    for table, cases in CENSUSTESTDATA.items():
         data = census(AL, table=table, geometry="block group")
         columns = set(variables(table).values()) | {"GEOID20"}
         
@@ -178,27 +167,8 @@ def test_census_blocks():
     AL = us.states.AL
     blocks = 185976
 
-    tests = {
-        "P1": [
-            ("TOTPOP20", 5024279),
-            ("WHITEASIANPOP20", 18510)
-        ],
-        "P2": [
-            ("NHWHITEAMINASIANPOP20", 821),
-            ("HPOP20", 264047)
-        ],
-        "P3": [
-            ("WHITEASIANOTHVAP20", 201),
-            ("VAP20", 3917166)
-        ],
-        "P4": [
-            ("NHBLACKASIANOTHVAP20", 31),
-            ("HVAP20", 166856)
-        ]
-    }
-
     # Get the data for each table and verify that the values are correct.
-    for table, cases in tests.items():
+    for table, cases in CENSUSTESTDATA.items():
         data = census(AL, table=table, geometry="block")
         columns = set(variables(table).values()) | {"GEOID20"}
         


### PR DESCRIPTION
- correctly names principal population columns when pulling from the Census PL94 and ACS data APIs;
- correctly accesses data at the block and block group levels from the Census PL94 API;
- implements more robust testing for pulled Census PL94 data.