### PR TITLE
Add a simplified EG score and change competitive districts -> contests

### DIFF
--- a/evaltools/scoring/__init__.py
+++ b/evaltools/scoring/__init__.py
@@ -13,7 +13,7 @@ from .reock import reock
 __all__ = [
     "splits",
     "pieces",
-    "competitive_districts",
+    "competitive_contests",
     "swing_districts",
     "party_districts",
     "opp_party_districts",
@@ -22,6 +22,7 @@ __all__ = [
     "signed_proportionality",
     "absolute_proportionality",
     "efficiency_gap",
+    "simplified_efficiency_gap",
     "mean_median",
     "partisan_bias",
     "partisan_gini",

--- a/evaltools/scoring/partisan.py
+++ b/evaltools/scoring/partisan.py
@@ -15,7 +15,7 @@ def _election_stability(part: Partition, election_cols: Tuple[str], party: str):
     return (_election_results(part, election_cols, party) > 0.5).sum(axis=0)
 
 
-def _competitive_districts(part: Partition, election_cols: Iterable[str], party: str,
+def _competitive_contests(part: Partition, election_cols: Iterable[str], party: str,
                           points_within: float = 0.03) -> PlanWideScoreValue:
     results = _election_results(part, tuple(election_cols), party)
     return int(np.logical_and(results > 0.5 - points_within, results < 0.5 + points_within).sum())
@@ -48,6 +48,14 @@ def _absolute_proportionality(part: Partition, election_cols: Iterable[str], par
 
 def _efficiency_gap(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
     return {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
+
+def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
+    result = {}
+    for e in election_cols:
+        V = part[e].percent(party)
+        S = part[e].seats(party) / len(part)
+        result[part[e].election.name] = S + 0.5 - 2*V
+    return result
 
 def _mean_median(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
     return {part[e].election.name: part[e].mean_median() for e in election_cols}

--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -5,13 +5,14 @@ from .demographics import (
     _gingles_districts,
 )
 from .partisan import (
-    _competitive_districts,
+    _competitive_contests,
     _swing_districts,
     _party_districts,
     _opp_party_districts,
     _party_wins_by_district,
     _seats,
     _efficiency_gap,
+    _simplified_efficiency_gap,
     _mean_median,
     _partisan_bias,
     _partisan_gini,
@@ -139,9 +140,9 @@ def pieces(unit: str, names:bool = False, alias: str = None) -> Score:
         alias = unit
     return Score(f"{alias}_pieces", partial(_pieces, unit=unit, names=names))
 
-def competitive_districts(election_cols: Iterable[str], party: str, points_within: float = 0.03) -> Score:
+def competitive_contests(election_cols: Iterable[str], party: str, points_within: float = 0.03, alias: str = None) -> Score:
     """
-    Score representing the number of competitive districts in a plan.
+    Score representing the number of competitive contests in a plan.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
@@ -154,7 +155,9 @@ def competitive_districts(election_cols: Iterable[str], party: str, points_withi
         A score object with name `"competitive_districts"` and associated function that takes a
         partition and returns a PlanWideScoreValue for the number of competitive districts.
     """
-    return Score("competitive_districts", partial(_competitive_districts, election_cols=election_cols,
+    if alias is None:
+        alias = "competitive_contests_{points_within}"
+    return Score(alias, partial(_competitive_contests, election_cols=election_cols,
                                                   party=party, points_within=points_within))
 
 def swing_districts(election_cols: Iterable[str], party: str) -> Score:
@@ -286,6 +289,23 @@ def efficiency_gap(election_cols: Iterable[str]) -> Score:
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
     return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols))
+
+def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -> Score:
+    """
+    Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+    The original formulation of efficiency gap quantifies the difference in "wasted" votes for the two
+    parties across the state, as a share of votes cast. This is sensitive to turnout effects. The 
+    simplified score is equal to standard efficiency gap when the districts have equal turnout.
+
+    Args:
+        election_cols (Iterable[str]): The names of the election updaters over which to compute
+            results for.
+
+    Returns:
+        A score object with name `"efficiency_gap"`  and associated function that takes a partition
+        and returns a PlanWideScoreValue for efficiency gap metric.
+    """
+    return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))
 
 def mean_median(election_cols: Iterable[str]) -> Score:
     """


### PR DESCRIPTION
This adds our `S + 0.5 - 2V` formulation of the efficiency gap to our scoring toolkit. I also made some small changes to the `competitive_districts()` function, changing its name and allowing one to use an alias for the `name` field. This would be helpful if one wants to calculate the number of competitive contests according to several different sets of elections, so you could distinguish between them.